### PR TITLE
use absolute path to babel-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "babel-plugins/babel-plugin-runtime",
   "license": "MIT",
   "main": "lib/index.js",
+  "dependencies": {
+    "babel-runtime": "5"
+  },
   "devDependencies": {
     "babel": "^5.6.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import definitions from "./definitions";
 
 export default function ({ Plugin, types: t }) {
-  const RUNTIME_MODULE_NAME = "babel-runtime";
+  const RUNTIME_MODULE_NAME = require.resolve("babel-runtime")
 
   function has(obj, key) {
     return Object.prototype.hasOwnProperty.call(obj, key);


### PR DESCRIPTION
this enables the compiled code to run without itself depending on babel-runtime. I'm not sure if this is all thats required or not. I will try test it now